### PR TITLE
Set subrequest output buffer size big enough to handle JWT payload

### DIFF
--- a/frontend.conf
+++ b/frontend.conf
@@ -4,6 +4,9 @@ upstream my_backend {
     server 10.0.0.1:80;
 }
 
+# Subrequest size should be enough to handle the JWT payload
+subrequest_output_buffer_size 8k;
+
 # Custom log format to include the 'sub' claim in the REMOTE_USER field
 log_format main_jwt '$remote_addr $jwt_claim_sub $remote_user [$time_local] "$request" $status '
                     '$body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for"';


### PR DESCRIPTION
The JWT payload size subrequest response size can be higher than the default `subrequest_output_buffer_size` (which is 4k or 8k depending on the host).

When it is the case, the `/_token` subrequest throws a "too big subrequest response" error.