### PR TITLE
Add support for groups claim

### DIFF
--- a/frontend.conf
+++ b/frontend.conf
@@ -12,6 +12,7 @@ log_format main_jwt '$remote_addr - $jwt_claim_sub [$time_local] "$request" $sta
 js_include conf.d/openid_connect.js;
 js_set $requestid_hash hashRequestId;
 auth_jwt_claim_set $jwt_audience aud; # In case aud is an array
+auth_jwt_claim_set $jwt_groups groups;
 
 keyval_zone zone=opaque_sessions:1M state=conf.d/opaque_sessions.json timeout=1h; # CHANGE timeout to JWT/exp validity period
 keyval_zone zone=refresh_tokens:1M  state=conf.d/refresh_tokens.json  timeout=8h; # CHANGE timeout to refresh validity period
@@ -46,6 +47,7 @@ server {
     set $oidc_client          "my-client-id";
     set $oidc_client_secret   "my-client-secret";
     set $oidc_hmac_key        "ChangeMe"; # This should be unique for every NGINX instance/cluster
+    set $oidc_group           "comma-seperated list of group-ids";
 
     listen 8010; # Use SSL/TLS in production
     


### PR DESCRIPTION
Adding this in the nginx config file should make the groups claim available in js:
auth_jwt_claim_set $jwt_groups groups;

And adding this to the nginx config should set the group ids that are allowed:
set $oidc_group "comma-seperated list of group-ids";

See documentation on this for azure here:
https://docs.microsoft.com/en-gb/azure/active-directory/develop/active-directory-optional-claims#configuring-groups-optional-claims

We have it running with the nginx-plus ingress controller in k8s to authenticate users with azure ad.