### PR TITLE
Construct redirect URIs when behind proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ $ cd nginx-openid-connect
 $ docker run -d -p 8010:8010 -v $PWD:/etc/nginx/conf.d nginx-plus nginx -g 'daemon off; load_module modules/ngx_http_js_module.so;'
 ```
 
+### Running behind another proxy or load balancer
+When NGINX Plus is deployed behind another proxy, the original protocol and port number are not available. NGINX Plus needs this information to construct the URIs it passes to the IdP and for redirects. By default NGINX Plus looks for the X-Forwarded-Proto and X-Forwarded-Port request headers to construct these URIs.
+
 ## Configuring your IdP
 
   * Create an OpenID Connect client to represent your NGINX Plus instance
@@ -104,6 +107,7 @@ Manual configuration involves reviewing the following files so that they match y
     * Modify all of the `map…$oidc_` blocks to match your IdP configuration
     * Modify the URI defined in `map…$oidc_logout_redirect` to specify an unprotected resource to be displayed after requesting the `/logout` location
     * Set a unique value for `$oidc_hmac_key` to ensure nonce values are unpredictable
+    * If NGINX Plus is deployed behind another proxy or load balancer, modify the `map…$redirect_base` and `map…$proto` blocks to define how to obtain the original protocol and port number.
 
   * **frontend.conf** - this is the reverse proxy configuration
     * Modify the upstream group to match your backend site or app

--- a/openid_connect.js
+++ b/openid_connect.js
@@ -35,7 +35,7 @@ function auth(r) {
         r.headersOut['Set-Cookie'] = [
             "auth_redir=" + r.variables.request_uri + "; " + r.variables.oidc_cookie_flags,
             "auth_nonce=" + noncePlain + "; " + r.variables.oidc_cookie_flags ];
-        r.return(302, r.variables.oidc_authz_endpoint + "?response_type=code&scope=" + r.variables.oidc_scopes + "&client_id=" + r.variables.oidc_client + "&state=0&redirect_uri="+ r.variables.scheme + "://" + r.variables.host + ":" + r.variables.server_port + r.variables.redir_location + "&nonce=" + nonceHash);
+        r.return(302, r.variables.oidc_authz_endpoint + "?response_type=code&scope=" + r.variables.oidc_scopes + "&client_id=" + r.variables.oidc_client + "&state=0&redirect_uri="+ r.variables.redirect_base + r.variables.redir_location + "&nonce=" + nonceHash);
         return;
     }
     
@@ -177,7 +177,7 @@ function codeExchange(r) {
                         r.log("OIDC success, creating session " + r.variables.request_id);
                         r.variables.new_session = tokenset.id_token; // Create key-value store entry
                         r.headersOut["Set-Cookie"] = "auth_token=" + r.variables.request_id + "; " + r.variables.oidc_cookie_flags;
-                        r.return(302, r.variables.cookie_auth_redir);
+                        r.return(302, r.variables.redirect_base + r.variables.cookie_auth_redir);
                    }
                 );
             } catch (e) {

--- a/openid_connect.server_conf
+++ b/openid_connect.server_conf
@@ -38,7 +38,7 @@
         internal;
         proxy_ssl_server_name on; # For SNI to the IdP
         proxy_set_header      Content-Type "application/x-www-form-urlencoded";
-        proxy_set_body        "grant_type=authorization_code&code=$arg_code&client_id=$oidc_client&client_secret=$oidc_client_secret&redirect_uri=$scheme://$host:$server_port$redir_location";
+        proxy_set_body        "grant_type=authorization_code&code=$arg_code&client_id=$oidc_client&client_secret=$oidc_client_secret&redirect_uri=$redirect_base$redir_location";
         proxy_method          POST;
         proxy_pass            $oidc_token_endpoint;
    }

--- a/openid_connect_configuration.conf
+++ b/openid_connect_configuration.conf
@@ -39,9 +39,19 @@ map $host $oidc_hmac_key {
     default "ChangeMe";
 }
 
-map $scheme $oidc_cookie_flags {
+map $proto $oidc_cookie_flags {
     http  "Path=/; SameSite=lax;"; # For HTTP/plaintext testing
     https "Path=/; SameSite=lax; HttpOnly; Secure;"; # Production recommendation
+}
+
+map $http_x_forwarded_port $redirect_base {
+    ""      $proto://$host:$server_port;
+    default $proto://$host:$http_x_forwarded_port;
+}
+
+map $http_x_forwarded_proto $proto {
+    ""      $scheme;
+    default $http_x_forwarded_proto;
 }
 
 # ADVANCED CONFIGURATION BELOW THIS LINE


### PR DESCRIPTION
When NGINX Plus is deployed behind another proxy, the original protocol and port number are not available. NGINX Plus needs this information to construct the URIs it passes to the IdP and for redirects. By default NGINX Plus looks for the X-Forwarded-Proto and X-Forwarded-Port request headers to construct these URIs.