### PR TITLE
Fix: unhandled exception if `code` is not present

### DIFF
--- a/openid_connect.js
+++ b/openid_connect.js
@@ -103,7 +103,7 @@ function auth(r) {
 
 function codeExchange(r) {
     // First check that we received an authorization code from the IdP
-    if (r.variables.arg_code.length == 0) {
+    if (r.variables.arg_code == undefined || r.variables.arg_code.length == 0) {
         if (r.variables.arg_error) {
             r.error("OIDC error receiving authorization code from IdP: " + r.variables.arg_error_description);
         } else {


### PR DESCRIPTION
In case of an error the `auth_code` will not be sent back from the IdP
with the `_codexch` requeset. Checking the length will result in an
unhandled exception. Checking undefined before the length.