### PR TITLE
Fix: Double URL encoding in proxy upstream after internalRedirect

### DIFF
--- a/openid_connect.js
+++ b/openid_connect.js
@@ -89,7 +89,7 @@ function auth(r) {
                         }
 
                         delete r.headersOut["WWW-Authenticate"]; // Remove evidence of original failed auth_jwt
-                        r.internalRedirect(r.variables.request_uri); // Continue processing original request
+                        r.internalRedirect(`${r.variables.uri}${r.variables.is_args ? `${r.variables.is_args}${r.variables.args}` : ``}`);
                     }
                 );
             } catch (e) {


### PR DESCRIPTION
In some scenarios the internal redirect will double encode the URI. This problem happens if a request was sent to NGINX with a `auth-token` cookie but the token needs to be refreshed and the key value store updated.

After the token update the internalRedirect will start the auth flow again and send the user finally to the defined upstream via proxy pass. With this fix the URI is normalized and will not be double encoded anymore.

Second Fix is slowing down the request processing in case the zone sync is not fast enough. This is a very rare case if the OIDC implementation is deployed on K8s.