### PR TITLE
Fix: ZoneSync delays in some installations caused problems

### DIFF
--- a/openid_connect_configuration.conf
+++ b/openid_connect_configuration.conf
@@ -43,6 +43,16 @@ map $host $oidc_hmac_key {
     default "ChangeMe";
 }
 
+map $host $zone_sync_leeway {
+    # Specifies the maximum timeout for synchronizing ID tokens between cluster
+    # nodes when you use shared memory zone content sync. This option is only
+    # recommended for scenarios where cluster nodes can randomly process
+    # requests from user agents and there may be a situation where node "A"
+    # successfully received a token, and node "B" receives the next request in
+    # less than zone_sync_interval.
+    default 0; # Time in milliseconds, e.g. (zone_sync_interval * 2 * 1000)
+}
+
 map $proto $oidc_cookie_flags {
     http  "Path=/; SameSite=lax;"; # For HTTP/plaintext testing
     https "Path=/; SameSite=lax; HttpOnly; Secure;"; # Production recommendation


### PR DESCRIPTION
- Fix: ZoneSync delays in some installations caused problems

   Fix is slowing down the request processing in case the zone sync is not fast enough. This issue may occur in environments where NGINX cluster nodes can randomly process requests from user agents and there may be a situation where node "A" successfully received a token, and node "B" receives the next request in less than zone_sync_interval.
   Introduced `zone_sync_leeway` variable that specifies the maximum timeout for synchronizing ID tokens between cluster nodes. The request doesn't wait until it reaches the timeout, if the "session_jwt" variable "appeared" in key-value database before the timeout expires, the request will be released.

- Fix: Double URL encoding in proxy upstream after internalRedirect

   In some cases the `r.internalRedirect(uri)` will double encode the URI. This problem may occur if OIDC module needs to update the set of tokens using the refresh token and redirect the user agent to the original request URI.