### PR TITLE
Allow extra args to be provided to the OIDC auth endpoint

### DIFF
--- a/openid_connect.js
+++ b/openid_connect.js
@@ -268,6 +268,10 @@ function getAuthZArgs(r) {
     var nonceHash = h.digest('base64url');
     var authZArgs = "?response_type=code&scope=" + r.variables.oidc_scopes + "&client_id=" + r.variables.oidc_client + "&redirect_uri="+ r.variables.redirect_base + r.variables.redir_location + "&nonce=" + nonceHash;
 
+    if (r.variables.oidc_authz_extra_args) {
+        authZArgs += "&" + r.variables.oidc_authz_extra_args;
+    }
+
     r.headersOut['Set-Cookie'] = [
         "auth_redir=" + r.variables.request_uri + "; " + r.variables.oidc_cookie_flags,
         "auth_nonce=" + noncePlain + "; " + r.variables.oidc_cookie_flags

--- a/openid_connect_configuration.conf
+++ b/openid_connect_configuration.conf
@@ -8,6 +8,18 @@ map $host $oidc_authz_endpoint {
     #www.example.com "https://my-idp/oauth2/v1/authorize";
 }
 
+map $host $oidc_authz_extra_args {
+    # Extra arguments to include in the request to the IdP's authorization
+    # endpoint.
+    # Some IdPs provide extended capabilities controlled by extra arguments,
+    # for example Keycloak can select an IdP to delegate to via the
+    # "kc_idp_hint" argument.
+    # Arguments must be expressed as query string parameters and URL-encoded
+    # if required.
+    default "";
+    #www.example.com "kc_idp_hint=another_provider"
+}
+
 map $host $oidc_token_endpoint {
     default "http://127.0.0.1:8080/auth/realms/master/protocol/openid-connect/token";
 }


### PR DESCRIPTION
Some OIDC Identity Providers provide extended capabilities by adding extra query string arguments to the authentication request.

Specifically, Keycloak allows a default identity provider to be specified by adding a "kc_idp_hint" parameter to the authentication request (see https://www.keycloak.org/docs/latest/server_admin/#_client_suggested_idp).

It would be great to be able to include extra request arguments provided by the configuration.