### PR TITLE
Added callback URLs for code exchange and logout

### DIFF
--- a/openid_connect.js
+++ b/openid_connect.js
@@ -198,7 +198,8 @@ function codeExchange(r) {
                             r.variables.new_access_token = "";
                         }
                         r.headersOut["Set-Cookie"] = "auth_token=" + r.variables.request_id + "; " + r.variables.oidc_cookie_flags;
-                        r.return(302, r.variables.redirect_base + r.variables.cookie_auth_redir);
+                        const redirectLocation = r.variables.after_codexch_redir || r.variables.cookie_auth_redir
+                        r.return(302, r.variables.redirect_base + redirectLocation);
                    }
                 );
             } catch (e) {
@@ -268,7 +269,10 @@ function logout(r) {
     r.variables.session_jwt   = "-";
     r.variables.access_token  = "-";
     r.variables.refresh_token = "-";
-    r.return(302, r.variables.oidc_logout_redirect);
+    const redirectLocation = r.variables.initial_logout_redir
+        ? `${r.variables.redirect_base}${r.variables.initial_logout_redir}`
+        : r.variables.oidc_logout_redirect;
+    r.return(302, redirectLocation);
 }
 
 function getAuthZArgs(r) {

--- a/openid_connect.server_conf
+++ b/openid_connect.server_conf
@@ -24,7 +24,6 @@
         default_type text/plain; # In case we throw an error
     }
 
-    set $redir_location "/_codexch";
     location = /_codexch {
         # This location is called by the IdP after successful authentication
         status_zone "OIDC code exchange";

--- a/openid_connect_configuration.conf
+++ b/openid_connect_configuration.conf
@@ -3,6 +3,21 @@
 # Each map block allows multiple values so that multiple IdPs can be supported,
 # the $host variable is used as the default input parameter but can be changed.
 #
+map $host $redir_location {
+    # www.example.com  "/signin-oidc"; # need to add the /signin-oidc location and code exchange process 
+    default "/_codexch";
+}
+
+map $host $after_codexch_redir {
+    default "";
+    #www.example.com "/after_code_verified";
+}
+
+map $host $initial_logout_redir {
+    default "";
+    #www.example.com "/clear_proxy_session";
+}
+
 map $host $oidc_authz_endpoint {
     default "http://127.0.0.1:8080/auth/realms/master/protocol/openid-connect/auth";
     #www.example.com "https://my-idp/oauth2/v1/authorize";


### PR DESCRIPTION
Problem:
Could not provide dynamic code exchange URL, custom session start after code exchanges and session end during logout.
Background:

To use NGINX as an API Gateway for various products we need to add context information with a callback URL for the product which needs a dynamic URL for code exchange based on the product settings
Similarly, we need a callback for products
 
Description:
-  made code exchange redirect location a map so that it can be set based on URL
- Added two new variables for After Code Exchange redirect and initial logout URL 
