### PR TITLE
Do not pass client headers or body to the IdP token endpoint.

### DIFF
--- a/openid_connect.server_conf
+++ b/openid_connect.server_conf
@@ -37,6 +37,12 @@
         # to construct the OpenID Connect token request, as per:
         #  http://openid.net/specs/openid-connect-core-1_0.html#TokenRequest
         internal;
+
+        # Do not pass through body or headers from the client, this should be a net-new connection.
+        # Some IdPs, like Microsoft Entra, will throw CORS errors if client headers are passed through.
+        proxy_pass_request_headers off;
+        proxy_pass_request_body off;
+
         proxy_ssl_server_name on; # For SNI to the IdP
         proxy_set_header      Content-Type "application/x-www-form-urlencoded";
         proxy_set_body        "grant_type=authorization_code&client_id=$oidc_client&$args&redirect_uri=$redirect_base$redir_location";
@@ -49,6 +55,12 @@
         # use the proxy_ directives to construct the OpenID Connect token request, as per:
         #  https://openid.net/specs/openid-connect-core-1_0.html#RefreshingAccessToken
         internal;
+
+        # Do not pass through body or headers from the client, this should be a net-new connection.
+        # Some IdPs, like Microsoft Entra, will throw CORS errors if client headers are passed through.
+        proxy_pass_request_headers off;
+        proxy_pass_request_body off;
+
         proxy_ssl_server_name on; # For SNI to the IdP
         proxy_set_header      Content-Type "application/x-www-form-urlencoded";
         proxy_set_body        "grant_type=refresh_token&refresh_token=$arg_token&client_id=$oidc_client&client_secret=$oidc_client_secret";


### PR DESCRIPTION
This change resolves CORS failures seen when using Microsoft IdPs.

Related MS error codes:
- AADSTS9002326
- AADSTS9002327