### PR TITLE
Refactor Session ID handling

### DIFF
--- a/openid_connect.js
+++ b/openid_connect.js
@@ -272,9 +272,22 @@ function logout(r) {
     r.return(302, r.variables.oidc_logout_redirect);
 }
 
+/**
+ * Generates a random string ID with a specified length.
+ *
+ * @param {number} keyLength - Length of the generated ID. If it's less than 20,
+ * the default value of 20 will be used.
+ * @returns {string} - A randomly generated string ID in hexadecimal format.
+ */
+function generateID(keyLength) {
+    keyLength = keyLength > 20 ? keyLength : 20;
+    let buf = Buffer.alloc(keyLength);
+    return (crypto.getRandomValues(buf)).toString('hex');
+}
+
 function getAuthZArgs(r) {
     // Choose a nonce for this flow for the client, and hash it for the IdP
-    var noncePlain = r.variables.request_id;
+    var noncePlain = generateID();
     var c = require('crypto');
     var h = c.createHmac('sha256', r.variables.oidc_hmac_key).update(noncePlain);
     var nonceHash = h.digest('base64url');

--- a/openid_connect.js
+++ b/openid_connect.js
@@ -273,7 +273,7 @@ function logout(r) {
 }
 
 function generateID(keyLength) {
-    keyLength = keyLength > 20 ? keyLength : 20;
+    keyLength = keyLength > 16 ? keyLength : 16;
     let buf = Buffer.alloc(keyLength);
     return (crypto.getRandomValues(buf)).toString('hex');
 }

--- a/openid_connect.js
+++ b/openid_connect.js
@@ -410,13 +410,6 @@ function updateTokens(r, tokenset) {
         if (tokenset.refresh_token) {
             r.variables.new_refresh = tokenset.refresh_token;
             r.log(`New OIDC refresh token stored for session ${r.variables.oidc_keyval_id_rotate}`);
-
-            // The R31 39334b6616690b652bad9fa5f0d3c72df8759ece implementation had a comment that said "Update refresh token (if we got a new one)"
-            // However, if no refresh_token was in the tokenset response tokenset.refresh_token would be undefined, triggering the != comparison,
-            //   so r.variables.refresh_token would be set to undefined.
-            // The commented out else if matches the R31 comment behavior of "update only if new", but is commented out as that is not the actual behavior.
-            //} else if (r.variables.oidc_keyval_id_current && r.variables.refresh_token && r.variables.refresh_token != "-") {
-            // r.variables.new_refresh = r.variables.refresh_token
         } else {
             r.variables.new_refresh = "-";
             r.warn(`OIDC no refresh token for session ${r.variables.oidc_keyval_id_rotate}`);

--- a/openid_connect_configuration.conf
+++ b/openid_connect_configuration.conf
@@ -92,15 +92,22 @@ keyval_zone zone=oidc_access_tokens:1M state=conf.d/oidc_access_tokens.json time
 keyval_zone zone=refresh_tokens:1M     state=conf.d/refresh_tokens.json     timeout=8h;
 keyval_zone zone=oidc_pkce:128K timeout=90s; # Temporary storage for PKCE code verifier.
 
-keyval $cookie_auth_token $session_jwt   zone=oidc_id_tokens;     # Exchange cookie for JWT
-keyval $cookie_auth_token $access_token  zone=oidc_access_tokens; # Exchange cookie for access token
-keyval $cookie_auth_token $refresh_token zone=refresh_tokens;     # Exchange cookie for refresh token
-keyval $request_id $new_session          zone=oidc_id_tokens;     # For initial session creation
-keyval $request_id $new_access_token     zone=oidc_access_tokens;
-keyval $request_id $new_refresh          zone=refresh_tokens; # ''
+# NON-CONFIGURATION BELOW THIS LINE
+keyval $oidc_keyval_id_current $session_jwt   zone=oidc_id_tokens;     # Exchange cookie for JWT
+keyval $oidc_keyval_id_current $access_token  zone=oidc_access_tokens; # Exchange cookie for access token
+keyval $oidc_keyval_id_current $refresh_token zone=refresh_tokens;     # Exchange cookie for refresh token
+
+# These variables are used on create and update.  Calling them will rotate the client session token.
+keyval $oidc_keyval_id_rotate  $new_session          zone=oidc_id_tokens;
+keyval $oidc_keyval_id_rotate  $new_access_token     zone=oidc_access_tokens;
+keyval $oidc_keyval_id_rotate  $new_refresh          zone=refresh_tokens;
+
 keyval $pkce_id $pkce_code_verifier      zone=oidc_pkce;
 
 auth_jwt_claim_set $jwt_audience aud; # In case aud is an array
 js_import oidc from conf.d/openid_connect.js;
+
+js_set $oidc_keyval_id_current oidc.generateKeyValIDCurrent; # Current keyval ID, persistent, based off client inputs (Cookies)
+js_set $oidc_keyval_id_rotate oidc.generateKeyValIDRotate;  # Rotate keyval ID, for setting new values.  Random.  Do not call outside this module as it will rotate the client session token.
 
 # vim: syntax=nginx


### PR DESCRIPTION
This PR hardens the implementation to use random values instead of the request_id for the OIDC Nonce and client session access token.  The major changes are:

- Adds generateID() function from https://github.com/nginxinc/nginx-saml/blob/c3baf97d2c90e8a597803efd819095353881da83/saml_sp.js#L551 without modifications
- Use generateID() to generate the token request Nonce value
- Use generateID() to generate the client session token
- Use a HMAC hash of the client session token as the keyval keys and log IDs to help protect against session theft.
- Rotate the client session token each refresh

Rotating the client session token each refresh is the only real behavior change introduced.  This will result in a Cookie set header being added to non-OIDC requests when the session token is refreshed.  This change was made as a general security improvement, but mostly because it simplifies the implementation allowing for one keyval store update codepath for both new sessions and refreshes.

Other than the rotation this change should be a no-op behavior wise.  I have made an effort to verify the major behaviors and it passes my testing.