### PR TITLE
Change livelogs endpoint to use http rather than https

### DIFF
--- a/frontend.conf
+++ b/frontend.conf
@@ -39,7 +39,7 @@ server {
         add_header X-Frame-Options SAMEORIGIN always;
         add_header Content-Security-Policy "default-src 'self' 'unsafe-inline' 'unsafe-eval' SSO_DNS; script-src 'self' 'unsafe-inline' 'unsafe-eval' SSO_DNS;";
 
-        proxy_pass          https://LIVELOGS_KIBANA_IP:5601;
+        proxy_pass          http://LIVELOGS_KIBANA_IP:5601;
         proxy_set_header    Host $host;
         proxy_set_header    X-Real-IP $remote_addr;
         proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -67,7 +67,7 @@ server {
         add_header X-Frame-Options SAMEORIGIN always;
         add_header Content-Security-Policy "default-src 'self' 'unsafe-inline' 'unsafe-eval' SSO_DNS; script-src 'self' 'unsafe-inline' 'unsafe-eval' SSO_DNS;";
 
-        proxy_pass          https://LIVELOGS_KIBANA_IP:5601;
+        proxy_pass          http://LIVELOGS_KIBANA_IP:5601;
         proxy_set_header    Host $host;
         proxy_set_header    X-Real-IP $remote_addr;
         proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/frontend.conf
+++ b/frontend.conf
@@ -1,44 +1,79 @@
 # This is the backend application we are protecting with OpenID Connect
-upstream my_backend {
-    zone my_backend 64k;
-    server 10.0.0.1:80;
-}
-
 # Custom log format to include the 'sub' claim in the REMOTE_USER field
 log_format main_jwt '$remote_addr - $jwt_claim_sub [$time_local] "$request" $status '
                     '$body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
 
 # The frontend server - reverse proxy with OpenID Connect authentication
-#
+
 server {
     include conf.d/openid_connect.server_conf; # Authorization code flow and Relying Party processing
     error_log /var/log/nginx/error.log debug;  # Reduce severity level as required
 
-    listen 8010; # Use SSL/TLS in production
-    
+    listen 443 ssl; # Use SSL/TLS in production
+
+    ssl_certificate /srv/certs/livelogs.crt;
+    ssl_certificate_key /srv/certs/livelogs.key;
+
+    server_name LIVELOGS_NGINX_SERVER_DNS;
+
     location / {
         # This site is protected with OpenID Connect
         auth_jwt "" token=$session_jwt;
         error_page 401 = @do_oidc_flow;
 
-        auth_jwt_key_file $oidc_jwt_keyfile; # Enable when using filename
-        #auth_jwt_key_request /_jwks_uri; # Enable when using URL
+        auth_jwt_key_request /_jwks_uri; # Enable when using URL
 
         # Successfully authenticated users are proxied to the backend,
         # with 'sub' claim passed as HTTP header
         proxy_set_header username $jwt_claim_sub;
 
         # Bearer token is uses to authorize NGINX to access protected backend
-        #proxy_set_header Authorization "Bearer $access_token";
-        
+        proxy_set_header Authorization "Bearer $access_token";
+        proxy_set_header X-Original-URI $request_uri;
         # Intercept and redirect "401 Unauthorized" proxied responses to nginx
         # for processing with the error_page directive. Necessary if Access Token
         # can expire before ID Token.
-        #proxy_intercept_errors on;
+        # proxy_intercept_errors on;
 
-        proxy_pass http://my_backend; # The backend site/app
+        add_header Access-Control-Allow-Origin '*' always;
+        add_header X-Frame-Options SAMEORIGIN always;
+        add_header Content-Security-Policy "default-src 'self' 'unsafe-inline' 'unsafe-eval' SSO_DNS; script-src 'self' 'unsafe-inline' 'unsafe-eval' SSO_DNS;";
+
+        proxy_pass          https://LIVELOGS_KIBANA_IP:5601;
+        proxy_set_header    Host $host;
+        proxy_set_header    X-Real-IP $remote_addr;
+        proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header    X-Forwarded-Proto $scheme;
+        proxy_set_header    X-Forwarded-Host $http_host;
 
         access_log /var/log/nginx/access.log main_jwt;
+    }
+
+    location ~ (/app|/translations|/node_modules|/built_assets/|/bundles|/es_admin|/plugins|/api|/ui|/elasticsearch|/spaces/enter|internal) {
+        # auth_jwt "" token=$session_jwt;
+        # error_page 401 = @do_oidc_flow;
+
+        # auth_jwt_key_request /_jwks_uri; # Enable when using URL
+
+        # Successfully authenticated users are proxied to the backend,
+        # with 'sub' claim passed as HTTP header
+        proxy_set_header username $jwt_claim_sub;
+
+        # Bearer token is uses to authorize NGINX to access protected backend
+        proxy_set_header Authorization "Bearer $access_token";
+        proxy_set_header X-Original-URI $request_uri;
+
+        add_header Access-Control-Allow-Origin '*' always;
+        add_header X-Frame-Options SAMEORIGIN always;
+        add_header Content-Security-Policy "default-src 'self' 'unsafe-inline' 'unsafe-eval' SSO_DNS; script-src 'self' 'unsafe-inline' 'unsafe-eval' SSO_DNS;";
+
+        proxy_pass          https://LIVELOGS_KIBANA_IP:5601;
+        proxy_set_header    Host $host;
+        proxy_set_header    X-Real-IP $remote_addr;
+        proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header    X-Forwarded-Proto $scheme;
+        proxy_set_header    X-Forwarded-Host $http_host;
+        proxy_hide_header   Authorization;
     }
 }
 

--- a/openid_connect_configuration.conf
+++ b/openid_connect_configuration.conf
@@ -86,10 +86,15 @@ map $http_x_forwarded_proto $proto {
 # JWK Set will be fetched from $oidc_jwks_uri and cached here - ensure writable by nginx user
 proxy_cache_path /var/cache/nginx/jwk levels=1 keys_zone=jwk:64k max_size=1m;
 
+# NOTE #
+# ---- #
+# path has to be the one which is writable by the nginx user
+# https://docs.nginx.com/nginxaas/azure/management/nginx-configuration/#nginx-filesystem-restrictions
+
 # Change timeout values to at least the validity period of each token type
-keyval_zone zone=oidc_id_tokens:1M     state=conf.d/oidc_id_tokens.json     timeout=1h;
-keyval_zone zone=oidc_access_tokens:1M state=conf.d/oidc_access_tokens.json timeout=1h;
-keyval_zone zone=refresh_tokens:1M     state=conf.d/refresh_tokens.json     timeout=8h;
+keyval_zone zone=oidc_id_tokens:1M     state=/srv/oidc_id_tokens.json     timeout=1h;
+keyval_zone zone=oidc_access_tokens:1M state=/srv/oidc_access_tokens.json timeout=1h;
+keyval_zone zone=refresh_tokens:1M     state=/srv/refresh_tokens.json     timeout=8h;
 keyval_zone zone=oidc_pkce:128K timeout=90s; # Temporary storage for PKCE code verifier.
 
 keyval $cookie_auth_token $session_jwt   zone=oidc_id_tokens;     # Exchange cookie for JWT


### PR DESCRIPTION
Using https for livelogs kibana endpoint breaks and gives 502. Currently livelogs endpoint (IP) is working on http. 