### PR TITLE
Add support for RP-initiated OIDC logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ If a [refresh token](https://openid.net/specs/openid-connect-core-1_0.html#Refre
 
 Requests made to the `/logout` location invalidate both the ID token, access token and refresh token by erasing them from the key-value store. Therefore, subsequent requests to protected resources will be treated as a first-time request and send the client to the IdP for authentication. Note that the IdP may issue cookies such that an authenticated session still exists at the IdP.
 
+#### RP-Initiated OIDC Logout
+
+RP-initiated logout is supported according to [OpenID Connect RP-Initiated Logout 1.0](https://openid.net/specs/openid-connect-rpinitiated-1_0.html). This behavior is controlled by the `$oidc_end_session_endpoint` variable.
+
 ### Multiple IdPs
 
 Where NGINX Plus is configured to proxy requests for multiple websites or applications, or user groups, these may require authentication by different IdPs. Separate IdPs can be configured, with each one matching on an attribute of the HTTP request, e.g. hostname or part of the URI path.
@@ -137,11 +141,13 @@ When NGINX Plus is deployed behind another proxy, the original protocol and port
     * Set the **redirect URI** to the address of your NGINX Plus instance (including the port number), with `/_codexch` as the path, e.g. `https://my-nginx.example.com:443/_codexch`
     * Ensure NGINX Plus is configured as a confidential client (with a client secret) or a public client (with PKCE S256 enabled)
     * Make a note of the `client ID` and `client secret` if set
+    * Set the **post logout redirect URI** to the address of your NGINX Plus instance (including the port number), with `/_logout` as the path, e.g. `https://my-nginx.example.com:443/_logout`
 
   * If your IdP supports OpenID Connect Discovery (usually at the URI `/.well-known/openid-configuration`) then use the `configure.sh` script to complete configuration. In this case you can skip the next section. Otherwise:
     * Obtain the URL for `jwks_uri` or download the JWK file to your NGINX Plus instance
     * Obtain the URL for the **authorization endpoint**
     * Obtain the URL for the **token endpoint**
+    * Obtain the URL for the **end session endpoint**
 
 ## Configuring NGINX Plus
 
@@ -165,7 +171,7 @@ Manual configuration involves reviewing the following files so that they match y
 
   * **openid_connect.server_conf** - this is the NGINX configuration for handling the various stages of OpenID Connect authorization code flow
     * No changes are usually required here
-    * Modify the `resolver` directive to match a DNS server that is capable of resolving the IdP defined in `$oidc_token_endpoint`
+    * Modify the `resolver` directive to match a DNS server that is capable of resolving the IdP defined in `$oidc_token_endpoint` and `$oidc_end_session_endpoint`
     * If using [`auth_jwt_key_request`](http://nginx.org/en/docs/http/ngx_http_auth_jwt_module.html#auth_jwt_key_request) to automatically fetch the JWK file from the IdP then modify the validity period and other caching options to suit your IdP
 
   * **openid_connect.js** - this is the JavaScript code for performing the authorization code exchange and nonce hashing

--- a/openid_connect.server_conf
+++ b/openid_connect.server_conf
@@ -8,7 +8,7 @@
 
     location = /_jwks_uri {
         internal;
-        proxy_cache jwk;                              # Cache the JWK Set recieved from IdP
+        proxy_cache jwk;                              # Cache the JWK Set received from IdP
         proxy_cache_valid 200 12h;                    # How long to consider keys "fresh"
         proxy_cache_use_stale error timeout updating; # Use old JWK Set if cannot reach IdP
         proxy_ssl_server_name on;                     # For SNI to the IdP
@@ -29,9 +29,9 @@
         # This location is called by the IdP after successful authentication
         status_zone "OIDC code exchange";
         js_content oidc.codeExchange;
-        error_page 500 502 504 @oidc_error; 
+        error_page 500 502 504 @oidc_error;
     }
-   
+
     location = /_token {
         # This location is called by oidcCodeExchange(). We use the proxy_ directives
         # to construct the OpenID Connect token request, as per:
@@ -68,8 +68,9 @@
 
     location = /logout {
         status_zone "OIDC logout";
-        add_header Set-Cookie "auth_token=; $oidc_cookie_flags"; # Send empty cookie
-        add_header Set-Cookie "auth_redir=; $oidc_cookie_flags"; # Erase original cookie
+        add_header Set-Cookie "auth_token=; $oidc_cookie_flags";
+        add_header Set-Cookie "auth_nonce=; $oidc_cookie_flags";
+        add_header Set-Cookie "auth_redir=; $oidc_cookie_flags";
         js_content oidc.logout;
     }
 

--- a/openid_connect_configuration.conf
+++ b/openid_connect_configuration.conf
@@ -28,6 +28,13 @@ map $host $oidc_jwt_keyfile {
     default "http://127.0.0.1:8080/auth/realms/master/protocol/openid-connect/certs";
 }
 
+map $host $oidc_end_session_endpoint {
+    # Specifies the end_session_endpoint URL for RP-initiated logout.
+    # If this variable is empty or not set, the default behavior is maintained,
+    # which logs out only on the NGINX side.
+    default "";
+}
+
 map $host $oidc_client {
     default "my-client-id";
 }


### PR DESCRIPTION
Implement support for RP-initiated logout in accordance with OpenID Connect RP-Initiated Logout 1.0. Introduce the `oidc_end_session_endpoint` variable to specify the `end_session_endpoint` URL.

If `oidc_end_session_endpoint` is not set or is empty, the default behavior of logging out only on the NGINX side is maintained. When set, the endpoint triggers the RP-initiated logout as specified in the OIDC specification.

This PR is based on the revised PR #87 initially submitted by user @llomgui. Thank you to @llomgui for the initial implementation and contribution.

### Summary of Changes
- Added `oidc_end_session_endpoint` variable to specify the OIDC end session endpoint URL.
- Updated the `logout` function to:
  - Handle RP-initiated logout by redirecting to the specified `end_session_endpoint`.
  - Include logic to renew ID token if refresh token is available, but `session_jwt` is expired.
  - Fall back to traditional logout if both tokens are absent.
