### PR TITLE
Fixed ID token nonce claim validation

### DIFF
--- a/openid_connect.js
+++ b/openid_connect.js
@@ -3,8 +3,6 @@
  *
  * Copyright (C) 2020 Nginx, Inc.
  */
-var newSession = false; // Used by oidcAuth() and validateIdToken()
-
 export default {auth, codeExchange, validateIdToken, logout};
 
 function retryOriginalRequest(r) {
@@ -32,8 +30,6 @@ function auth(r, afterSyncCheck) {
     }
 
     if (!r.variables.refresh_token || r.variables.refresh_token == "-") {
-        newSession = true;
-
         // Check we have all necessary configuration variables (referenced only by njs)
         var oidcConfigurables = ["authz_endpoint", "scopes", "hmac_key", "cookie_flags"];
         var missingConfig = [];
@@ -240,6 +236,8 @@ function validateIdToken(r) {
         r.error("OIDC ID Token validation error: aud claim (" + r.variables.jwt_audience + ") does not include configured $oidc_client (" + r.variables.oidc_client + ")");
         validToken = false;
     }
+
+    var newSession = (!r.variables.refresh_token || r.variables.refresh_token == "-");
 
     // If we receive a nonce in the ID Token then we will use the auth_nonce cookies
     // to check that the JWT can be validated as being directly related to the

--- a/openid_connect.js
+++ b/openid_connect.js
@@ -237,7 +237,7 @@ function validateIdToken(r) {
         validToken = false;
     }
 
-    // https://openid.net/specs/openid-connect-core-1_0.html#IDToken:
+    // According to OIDC Core 1.0 Section 2:
     // "If present in the ID Token, Clients MUST verify that the nonce Claim Value is equal to the value of the nonce parameter sent in the Authentication Request."
     if (r.variables.jwt_claim_nonce) {
         var client_nonce_hash = "";

--- a/openid_connect.js
+++ b/openid_connect.js
@@ -250,16 +250,13 @@ function validateIdToken(r) {
             r.error("OIDC ID Token validation error: nonce from token (" + r.variables.jwt_claim_nonce + ") does not match client (" + client_nonce_hash + ")");
             validToken = false;
         }
+    } else if (!r.variables.refresh_token || r.variables.refresh_token == "-") {
+        r.error("OIDC ID Token validation error: nonce absent in first token of the session");
+        validToken = false;
     } else {
-        var newSession = (!r.variables.refresh_token || r.variables.refresh_token == "-");
-        if (newSession) {
-            r.error("OIDC ID Token validation error: nonce absent in token");
-            validToken = false;
-        } else {
-            // Tolerate missing nonce on renewals
-            // https://github.com/nginxinc/nginx-openid-connect/pull/104#issuecomment-2433361196
-            r.warn("OIDC ID Token validation error: No nonce claim");
-        }
+        // Tolerate missing nonce on renewals
+        // https://github.com/nginxinc/nginx-openid-connect/pull/104#issuecomment-2433361196
+        r.warn("OIDC ID Token validation warning: No nonce claim in token aquired through refresh");
     }
 
     if (validToken) {

--- a/openid_connect.js
+++ b/openid_connect.js
@@ -253,10 +253,6 @@ function validateIdToken(r) {
     } else if (!r.variables.refresh_token || r.variables.refresh_token == "-") {
         r.error("OIDC ID Token validation error: nonce absent in first token of the session");
         validToken = false;
-    } else {
-        // Tolerate missing nonce on renewals
-        // https://github.com/nginxinc/nginx-openid-connect/pull/104#issuecomment-2433361196
-        r.warn("OIDC ID Token validation warning: No nonce claim in token aquired through refresh");
     }
 
     if (validToken) {

--- a/openid_connect.js
+++ b/openid_connect.js
@@ -251,7 +251,7 @@ function validateIdToken(r) {
             validToken = false;
         }
     } else if (!r.variables.refresh_token || r.variables.refresh_token == "-") {
-        r.error("OIDC ID Token validation error: nonce absent in first token of the session");
+        r.error("OIDC ID Token validation error: missing nonce claim in ID Token during initial authentication.");
         validToken = false;
     }
 


### PR DESCRIPTION
Previously, ID token nonce claim validation was skipped in all cases due to lack of detection of if the session was a new session.