### PR TITLE
Fix OIDC client authentication for POST method after f7e8726

### DIFF
--- a/openid_connect.server_conf
+++ b/openid_connect.server_conf
@@ -38,10 +38,8 @@
         #  http://openid.net/specs/openid-connect-core-1_0.html#TokenRequest
         internal;
 
-        # Do not pass through body or headers from the client, this should be a net-new connection.
-        # Some IdPs, like Microsoft Entra, will throw CORS errors if client headers are passed through.
+        # Exclude client headers to avoid CORS errors with certain IdPs (e.g., Microsoft Entra ID)
         proxy_pass_request_headers off;
-        proxy_pass_request_body off;
 
         proxy_ssl_server_name on; # For SNI to the IdP
         proxy_set_header      Content-Type "application/x-www-form-urlencoded";
@@ -55,10 +53,8 @@
         #  https://openid.net/specs/openid-connect-core-1_0.html#RefreshingAccessToken
         internal;
 
-        # Do not pass through body or headers from the client, this should be a net-new connection.
-        # Some IdPs, like Microsoft Entra, will throw CORS errors if client headers are passed through.
+        # Exclude client headers to avoid CORS errors with certain IdPs (e.g., Microsoft Entra ID)
         proxy_pass_request_headers off;
-        proxy_pass_request_body off;
 
         proxy_ssl_server_name on; # For SNI to the IdP
         proxy_set_header      Content-Type "application/x-www-form-urlencoded";


### PR DESCRIPTION
Remove the `proxy_pass_request_body off` directive, which unintentionally broke OIDC client authentication using the POST body method (`client_secret_post`).

Previously, when `$oidc_client_auth_method` was set to "client_secret_post" the `generateTokenRequestParams()` function correctly formatted the POST request and sent it via `r.subrequest` to the internal `/_token` location. However, the `proxy_pass_request_body off` directive caused the POST request to reach `$oidc_token_endpoint` with a valid Content-Length header but an empty body. This led to a timeout as the OP token endpoint closed the connection.

Users encountered the error: "NGINX / OpenID Connect login failure."

This commit restores functionality by ensuring the request body is passed to the token endpoint while retaining header exclusion to prevent CORS issues.