### PR TITLE
Fix incorrect flag in token refresh flow

### DIFF
--- a/openid_connect.js
+++ b/openid_connect.js
@@ -46,7 +46,7 @@ async function auth(r, afterSyncCheck) {
 
     // Determine session ID and store session data
     const sessionId = getSessionId(r, false);
-    storeSessionData(r, sessionId, claims, tokenset, true);
+    storeSessionData(r, sessionId, claims, tokenset, false);
 
     r.log("OIDC success, refreshing session " + sessionId);
 


### PR DESCRIPTION
When refreshing tokens for an existing session, the code is storing session data to the wrong variables (`new_session`, `new_access_token`, `new_refresh`) instead of updating the existing session variables (`session_jwt`, `access_token`, `refresh_token`).

As a result, the existing session does not get the updated tokens, the session continuity breaks and the user is forced to re-authenticate.

The fix is to  set `isNewSession` to `false` when calling `storeSessionData`in the refresh flow.