### PR TITLE
Tests: added basic OIDC tests and CI workflow.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,67 @@
+name: OIDC test suite
+run-name: ${{ github.actor }} is triggering pipeline
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  test-njs-oidc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+  
+      - name: Install prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y apt-transport-https lsb-release apt-utils ubuntu-keyring gnupg2 \
+          ca-certificates wget mercurial
+
+      - name: Prepare keys and certificates
+        run: |
+          sudo mkdir /etc/ssl/nginx
+          echo '${{ secrets.NGINX_REPO_CRT }}' | sudo tee /etc/ssl/nginx/nginx-repo.crt > /dev/null
+          echo '${{ secrets.NGINX_REPO_KEY }}' | sudo tee /etc/ssl/nginx/nginx-repo.key > /dev/null
+
+      - name: Prepare NGINX Plus license token
+        run: |
+          echo '${{ secrets.NGINX_LIC }}' | tee $RUNNER_TEMP/lic > /dev/null
+
+      - name: Import NGINX Plus signing key
+        run: |
+          wget -qO - https://cs.nginx.com/static/keys/nginx_signing.key \
+          | gpg --dearmor \
+          | sudo tee /usr/share/keyrings/nginx-archive-keyring.gpg > /dev/null
+
+      - name: Configure NGINX Plus repository
+        run: |
+          echo "Acquire::https::pkgs-test.nginx.com::Verify-Peer \"true\";" | sudo tee -a /etc/apt/apt.conf.d/90nginx
+          echo "Acquire::https::pkgs-test.nginx.com::Verify-Host \"true\";" | sudo tee -a /etc/apt/apt.conf.d/90nginx
+          echo "Acquire::https::pkgs-test.nginx.com::SslCert     \"/etc/ssl/nginx/nginx-repo.crt\";" \
+          | sudo tee -a /etc/apt/apt.conf.d/90nginx
+          echo "Acquire::https::pkgs-test.nginx.com::SslKey      \"/etc/ssl/nginx/nginx-repo.key\";" \
+          | sudo tee -a /etc/apt/apt.conf.d/90nginx
+          printf "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] \
+          https://pkgs-test.nginx.com/nightly/ubuntu $(lsb_release -cs) nginx-plus\n" \
+          | sudo tee /etc/apt/sources.list.d/nginx-plus.list
+
+      - name: Install NGINX Plus
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y nginx-plus nginx-plus-module-njs
+
+      - name: Install Perl
+        run: |
+          sudo apt-get install -y perl libio-socket-ssl-perl
+
+      - name: Checkout nginx-test
+        run: |
+          git clone https://github.com/nginx/nginx-tests.git
+
+      - name: Run tests
+        working-directory: t
+        run: |
+          TEST_NGINX_BINARY=/usr/sbin/nginx TEST_NGINX_VERBOSE=1 \
+          TEST_NGINX_GLOBALS="load_module /etc/nginx/modules/ngx_http_js_module-debug.so; mgmt {license_token $RUNNER_TEMP/lic;}" \
+          prove -I../nginx-tests/lib -I./lib -v .

--- a/t/lib/Test/Nginx/OIDC.pm
+++ b/t/lib/Test/Nginx/OIDC.pm
@@ -1,0 +1,548 @@
+package Test::Nginx::OIDC;
+
+# Copyright (c) F5, Inc.
+#
+# This source code is licensed under the Apache License, Version 2.0 license
+# found in the LICENSE file in the root directory of this source tree.
+
+# Module for NJS OIDC tests.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use IO::Select;
+use IO::Socket::INET;
+use Socket qw/CRLF/;
+
+use Digest::SHA qw/hmac_sha256/;
+use JSON::PP qw/decode_json encode_json/;
+use MIME::Base64 qw/encode_base64/;
+use Test::Nginx qw/http/;
+
+use Exporter 'import';
+our @EXPORT_OK = qw/
+    parse_response
+    build_code_request
+    idp_socket
+    idp_daemon
+    set_state
+    get_state
+/;
+
+our $port;
+my $authorization_code = 'aaaa';
+
+###############################################################################
+
+sub parse_response {
+    my ($raw) = @_;
+    return unless defined $raw && length $raw;
+
+    my %r = (res => $raw);
+
+    if ($raw =~ /^HTTP\/\d+\.\d+\s+(\d{3})/) {
+        $r{status} = $1;
+    }
+
+    while ($raw =~ /^([^:\s]+):\s*([^\r\n]+)/gmi) {
+        my ($h, $v) = (lc $1, $2);
+        push @{ $r{headers}{$h} }, $v;
+        if ($h eq 'location') {
+            $r{location} = $v;
+        } elsif ($h eq 'set-cookie' && !exists $r{cookie}) {
+            $r{cookie} = $v;
+        }
+    }
+
+    my $loc = $r{location} // '';
+    if ($loc =~ /\?(.+)/) {
+        for my $kv (split /[&;]/, $1) {
+            my ($k, $v) = split /=/, $kv, 2;
+            next unless defined $k;
+            $v //= '';
+            $k =~ tr/+/ /;
+            $v =~ tr/+/ /;
+            $k =~ s/%([0-9A-Fa-f]{2})/chr hex $1/eg;
+            $v =~ s/%([0-9A-Fa-f]{2})/chr hex $1/eg;
+            $r{$k} = $v;
+        }
+    }
+
+    return \%r;
+}
+
+###############################################################################
+
+sub idp_socket {
+    IO::Socket::INET->new(
+        Proto    => 'tcp',
+        PeerAddr => "127.0.0.1:$port",
+    ) or die "Can't connect to mock IdP at 127.0.0.1:$port: $!\n";
+}
+
+sub build_code_request {
+    my ($flow, %opt) = @_;
+
+    my ($host, $path) = ($flow->{redirect_uri} // '') =~ m{^https?://([^/]+)(/.*)$}
+        or die "Unsupported redirect_uri in flow\n";
+
+    my %q = (
+        state => $flow->{state},
+        code  => ($opt{code} // $authorization_code),
+        (defined $opt{session_state} ? (session_state => $opt{session_state}) : ()),
+        %{ $opt{extra} // {} },
+    );
+    delete @q{ @{ $opt{omit} // [] } };
+
+    my $qs = join '&', map { "$_=$q{$_}" } sort keys %q;
+    my $uri = $path . ($qs ne '' ? "?$qs" : '');
+
+    my $cookie = defined $opt{cookie} ? $opt{cookie} : _cookie_header($flow);
+    my $r = "GET $uri HTTP/1.0" . CRLF
+          . "Host: $host" . CRLF
+          . "Connection: close" . CRLF;
+
+    $r .= "Cookie: $cookie" . CRLF if $cookie ne '';
+    $r .= CRLF;
+
+    return $r;
+}
+
+sub _cookie_header {
+    my ($flow) = @_;
+
+    my $set_cookie = $flow->{headers}{'set-cookie'} || [];
+    if (@$set_cookie) {
+        my @cookies = map {
+            my ($kv) = split /;/, ($_ // ''), 2;
+            $kv;
+        } @$set_cookie;
+        @cookies = grep { defined $_ && $_ ne '' } @cookies;
+        return join '; ', @cookies;
+    }
+
+    my ($kv) = split /;/, ($flow->{cookie} // ''), 2;
+    return $kv // '';
+}
+
+sub set_state {
+    my %params = @_;
+    my $body = join '&', map { "$_=$params{$_}" } keys %params;
+    _http_post('/set-state', $body, socket => idp_socket());
+}
+
+sub get_state {
+    my $response = _http_get('/get-state', socket => idp_socket());
+    my (undef, $body) = split /\r?\n\r?\n/, $response, 2;
+    return decode_json($body);
+}
+
+sub _http_get {
+    my ($url, %args) = @_;
+    my $req = "GET $url HTTP/1.0" . CRLF
+            . "Host: localhost" . CRLF
+            . "Connection: close" . CRLF
+            . CRLF;
+    return http($req, %args);
+}
+
+sub _http_post {
+    my ($url, $body, %args) = @_;
+    my $req = "POST $url HTTP/1.0" . CRLF
+            . "Host: localhost" . CRLF
+            . "Connection: close" . CRLF
+            . "Content-Length: " . length($body) . CRLF
+            . CRLF
+            . $body;
+    return http($req, %args);
+}
+
+###############################################################################
+
+sub idp_daemon {
+    my ($issuer, $client_id, $jwt_secret) = @_;
+
+    my $server = IO::Socket::INET->new(
+        Proto     => 'tcp',
+        LocalAddr => '127.0.0.1',
+        LocalPort => $port,
+        Listen    => 128,
+        Reuse     => 1,
+    ) or die "Can't create mock IdP listening socket: $!\n";
+
+    my $state = {
+        issuer        => $issuer,
+        client_id     => $client_id,
+        jwt_secret    => $jwt_secret,
+        jwt_kid       => 'test-kid',
+        nonce         => undef,
+        code_seq      => 0,
+        codes         => {},
+        token_hits    => 0,
+        id_token      => undef,
+        access_token  => undef,
+        refresh_token => undef,
+        requests      => {},
+    };
+
+    my $sel = IO::Select->new($server);
+
+    while (my @ready = $sel->can_read()) {
+        foreach my $s (@ready) {
+            if ($s == $server) {
+                my $c = $server->accept();
+                $sel->add($c) if $c;
+                next;
+            }
+
+            if (!$s->connected) {
+                $sel->remove($s);
+                $s->close();
+                delete $state->{requests}{$s};
+                next;
+            }
+
+            my ($method, $uri, $body) = _read_request($s, $state);
+            next unless defined $uri;
+
+            _route_request($s, $method, $uri, $body, $state);
+
+            $sel->remove($s);
+            $s->close();
+            delete $state->{requests}{$s};
+        }
+    }
+}
+
+sub _read_request {
+    my ($client, $state) = @_;
+
+    $state->{requests}{$client} = '' unless exists $state->{requests}{$client};
+    $state->{requests}{$client} .= $_ if $client->sysread($_, 65536);
+
+    return unless $state->{requests}{$client} =~ m/^\r?\n/mg;
+
+    my $cl = 0;
+    $cl = $1 if $state->{requests}{$client} =~ /^content-length:\s*([0-9]+)/mi;
+
+    return if $cl + pos($state->{requests}{$client}) > length($state->{requests}{$client});
+
+    my $body = '';
+    $body = substr($state->{requests}{$client}, pos($state->{requests}{$client}), $cl) if $cl > 0;
+
+    my $method = $1 if $state->{requests}{$client} =~ /^(\S+)\s+/;
+    my $uri    = $1 if $state->{requests}{$client} =~ /^\S+\s+([^ ]+)\s+HTTP/i;
+
+    return ($method, $uri, $body);
+}
+
+sub _route_request {
+    my ($client, $method, $uri, $body, $state) = @_;
+
+    my ($path, $query) = split /\?/, ($uri // ''), 2;
+    $query //= '';
+
+    if ($path eq '/auth') {
+        _handle_auth($client, $query, $state);
+        return;
+    }
+
+    if ($path eq '/set-state') {
+        _handle_set_state($client, $body, $state);
+        return;
+    }
+
+    if ($path eq '/get-state') {
+        _handle_get_state($client, $state);
+        return;
+    }
+
+    if ($path eq '/token') {
+        _handle_token($client, $body, $state);
+        return;
+    }
+
+    if ($path eq '/certs') {
+        _handle_keys($client, $state);
+        return;
+    }
+
+    _send_response($client, 404, "not found\n", {
+        'Content-Type' => 'text/plain',
+        'Connection'   => 'close',
+    });
+}
+
+sub _handle_auth {
+    my ($client, $query, $state) = @_;
+
+    my %p = _parse_params($query);
+
+    my $redirect_uri = $p{redirect_uri} // '';
+    my $nonce        = $p{nonce}        // '';
+    my $state_param  = defined $p{state} ? $p{state} : '0';
+
+    $state->{nonce} = $nonce;
+
+    my $code = sprintf("code%04d", ++$state->{code_seq});
+
+    $state->{codes}{$code} = {
+        nonce        => $nonce,
+        redirect_uri => $redirect_uri,
+        state        => $state_param,
+    };
+
+    my $sep = ($redirect_uri =~ /\?/) ? '&' : '?';
+    my $location = $redirect_uri . $sep . "code=$code&state=$state_param";
+
+    _send_response($client, 302, '', {
+        'Location'      => $location,
+        'Cache-Control' => 'no-store',
+        'Connection'    => 'close',
+    });
+}
+
+sub _handle_set_state {
+    my ($client, $body, $state) = @_;
+    my %p = _parse_params($body);
+
+    foreach my $k (keys %p) {
+        next if $k eq 'requests' || $k eq 'codes';
+        next unless exists $state->{$k};
+        $state->{$k} = $p{$k};
+    }
+
+    _send_response($client, 204, '', {
+        'Connection' => 'close',
+    });
+}
+
+sub _handle_get_state {
+    my ($client, $state) = @_;
+
+    my %public = %$state;
+    delete $public{requests};
+    delete $public{codes};
+
+    _send_response($client, 200, encode_json(\%public), {
+        'Content-Type' => 'application/json',
+        'Connection'   => 'close',
+    });
+}
+
+sub _handle_token {
+    my ($client, $body, $state) = @_;
+
+    $state->{token_hits}++;
+
+    my %p = _parse_params($body);
+    my $grant_type = $p{grant_type} // '';
+
+    if ($grant_type eq 'authorization_code') {
+        my $code = $p{code} // '';
+        my $rec  = $state->{codes}{$code};
+
+        unless ($rec || $code eq $authorization_code) {
+            _send_response($client, 400, encode_json({
+                error             => 'invalid_grant',
+                error_description => 'unknown code',
+            }), {
+                'Content-Type' => 'application/json',
+                'Connection'   => 'close',
+            });
+            return;
+        }
+
+        my $now = time();
+
+        my %claims = (
+            iss   => $state->{issuer},
+            sub   => 'user1',
+            aud   => $state->{client_id},
+            iat   => $now,
+            exp   => $now + 3600,
+            nonce => (defined $state->{nonce} ? $state->{nonce} : ($rec->{nonce} // '')),
+            sid   => 'sid1',
+        );
+
+        my $id_token = _encode_jwt_hs256(\%claims, $state->{jwt_secret}, $state->{jwt_kid});
+
+        my $access_token  = _random_token();
+        my $refresh_token = _random_token();
+        $state->{id_token} = $id_token;
+        $state->{access_token} = $access_token;
+        $state->{refresh_token} = $refresh_token;
+
+        my $resp = encode_json({
+            token_type    => 'Bearer',
+            expires_in    => 3600,
+            access_token  => $access_token,
+            refresh_token => $refresh_token,
+            id_token      => $id_token,
+        });
+
+        _send_response($client, 200, $resp, {
+            'Content-Type'  => 'application/json',
+            'Cache-Control' => 'no-store',
+            'Connection'    => 'close',
+        });
+
+        return;
+    }
+
+    if ($grant_type eq 'refresh_token') {
+        my $rt = $p{refresh_token} // '';
+        if (!$state->{refresh_token} || $rt ne $state->{refresh_token}) {
+            _send_response($client, 400, encode_json({
+                error             => 'invalid_grant',
+                error_description => 'invalid refresh_token',
+            }), {
+                'Content-Type' => 'application/json',
+                'Connection'   => 'close',
+            });
+            return;
+        }
+
+        my $now = time();
+
+        my %claims = (
+            iss => $state->{issuer},
+            sub => 'user1',
+            aud => $state->{client_id},
+            iat => $now,
+            exp => $now + 3600,
+            sid => 'sid1',
+        );
+
+        my $id_token = _encode_jwt_hs256(\%claims, $state->{jwt_secret}, $state->{jwt_kid});
+
+        my $access_token = _random_token();
+        $state->{id_token} = $id_token;
+        $state->{access_token} = $access_token;
+
+        my $resp = encode_json({
+            token_type    => 'Bearer',
+            expires_in    => 3600,
+            access_token  => $access_token,
+            id_token      => $id_token,
+        });
+
+        _send_response($client, 200, $resp, {
+            'Content-Type'  => 'application/json',
+            'Cache-Control' => 'no-store',
+            'Connection'    => 'close',
+        });
+
+        return;
+    }
+
+    _send_response($client, 400, encode_json({
+        error             => 'unsupported_grant_type',
+        error_description => "grant_type=$grant_type",
+    }), {
+        'Content-Type' => 'application/json',
+        'Connection'   => 'close',
+    });
+}
+
+sub _handle_keys {
+    my ($client, $state) = @_;
+
+    my $jwks = encode_json({
+        keys => [ {
+            kty => 'oct',
+            kid => $state->{jwt_kid},
+            use => 'sig',
+            alg => 'HS256',
+            k   => _b64url($state->{jwt_secret}),
+        } ],
+    });
+
+    _send_response($client, 200, $jwks, {
+        'Content-Type'  => 'application/json',
+        'Cache-Control' => 'max-age=3600',
+        'Connection'    => 'close',
+    });
+}
+
+sub _send_response {
+    my ($client, $status, $body, $headers) = @_;
+
+    $body ||= '';
+    $headers ||= {};
+
+    my $status_text = {
+        200 => 'OK',
+        302 => 'Found',
+        400 => 'Bad Request',
+        404 => 'Not Found',
+    }->{$status} || 'OK';
+
+    print $client "HTTP/1.1 $status $status_text" . CRLF;
+
+    $headers->{'Content-Length'} = length($body)
+        if !exists $headers->{'Content-Length'};
+
+    foreach my $h (keys %$headers) {
+        print $client "$h: $headers->{$h}" . CRLF;
+    }
+
+    print $client CRLF . $body;
+}
+
+sub _parse_params {
+    my ($query) = @_;
+    my %params;
+
+    foreach my $pair (split /&/, ($query // '')) {
+        next if $pair eq '';
+        my ($key, $value) = split /=/, $pair, 2;
+        $value //= '';
+        $key =~ tr/+/ /;
+        $value =~ tr/+/ /;
+        $key =~ s/%([0-9A-Fa-f]{2})/chr(hex($1))/eg;
+        $value =~ s/%([0-9A-Fa-f]{2})/chr(hex($1))/eg;
+        $params{$key} = $value;
+    }
+
+    return %params;
+}
+
+sub _encode_jwt_hs256 {
+    my ($claims, $secret, $kid) = @_;
+
+    my $header = {
+        typ => 'JWT',
+        alg => 'HS256',
+        kid => $kid,
+    };
+
+    my $h64 = _b64url(encode_json($header));
+    my $p64 = _b64url(encode_json($claims));
+
+    my $data = "$h64.$p64";
+    my $sig  = hmac_sha256($data, $secret);
+
+    return $data . '.' . _b64url($sig);
+}
+
+sub _b64url {
+    my ($raw) = @_;
+    my $b64 = encode_base64($raw, '');
+    $b64 =~ tr|+/|-_|;
+    $b64 =~ s/=+$//;
+    return $b64;
+}
+
+sub _random_token {
+    my @chars = ('a'..'z', 'A'..'Z', '0'..'9', '-', '_');
+    return join '', map { $chars[rand @chars] } 1..32;
+}
+
+###############################################################################
+
+1;
+
+###############################################################################

--- a/t/oidc_session.t
+++ b/t/oidc_session.t
@@ -1,0 +1,257 @@
+#!/usr/bin/perl
+
+# (C) Ivan Ovchinnikov
+# (C) Nginx, Inc.
+
+# Tests for njs-based OIDC SSO solution.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+
+use Test::Nginx;
+
+use Test::Nginx::OIDC qw/
+    parse_response
+    build_code_request
+    idp_socket
+    idp_daemon
+    set_state
+    get_state
+/;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+eval { require JSON::PP; };
+plan(skip_all => "JSON::PP not installed") if $@;
+
+my $idp_port   = port(8082);
+my $client_id  = 'test-client';
+my $jwt_secret = 'test-jwt-secret';
+my $issuer     = "http://127.0.0.1:$idp_port";
+
+my $t = Test::Nginx->new()->has(qw/http/)->plan(21);
+my $d = $t->testdir();
+
+###############################################################################
+# Copy the OIDC-related files into the test prefix.
+
+my $root = "$FindBin::Bin/..";
+
+sub slurp {
+    my ($path) = @_;
+    open my $fh, '<', $path or die "Can't open $path: $!\n";
+    local $/;
+    return <$fh>;
+}
+
+$t->write_file('openid_connect.js', slurp("$root/openid_connect.js"));
+$t->write_file('openid_connect.server_conf', slurp("$root/openid_connect.server_conf"));
+
+###############################################################################
+
+my $conf = <<'EOF';
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    proxy_cache_path jwk levels=1 keys_zone=jwk:64k max_size=1m;
+
+    keyval_zone zone=oidc_id_tokens:1M     state=oidc_id_tokens.json     timeout=1h;
+    keyval_zone zone=oidc_access_tokens:1M state=oidc_access_tokens.json timeout=1h;
+    keyval_zone zone=refresh_tokens:1M     state=refresh_tokens.json     timeout=8h;
+    keyval_zone zone=oidc_sids:1M          state=oidc_sids.json          timeout=8h;
+    keyval_zone zone=oidc_pkce:128k timeout=90s;
+
+    keyval $cookie_auth_token $session_jwt     zone=oidc_id_tokens;
+    keyval $cookie_auth_token $access_token    zone=oidc_access_tokens;
+    keyval $cookie_auth_token $refresh_token   zone=refresh_tokens;
+
+    keyval $request_id $new_session            zone=oidc_id_tokens;
+    keyval $request_id $new_access_token       zone=oidc_access_tokens;
+    keyval $request_id $new_refresh            zone=refresh_tokens;
+
+    keyval $pkce_id $pkce_code_verifier        zone=oidc_pkce;
+    keyval $idp_sid $client_sid                zone=oidc_sids;
+
+    auth_jwt_claim_set $jwt_audience aud;
+
+    js_import oidc from openid_connect.js;
+
+    map $http_x_forwarded_proto $proto {
+        ""      $scheme;
+        default $http_x_forwarded_proto;
+    }
+
+    map $http_x_forwarded_port $redirect_base {
+        ""      $proto://$host:$server_port;
+        default $proto://$host:$http_x_forwarded_port;
+    }
+
+    map $proto $oidc_cookie_flags {
+        http  "Path=/; SameSite=lax;";
+        https "Path=/; SameSite=lax; HttpOnly; Secure;";
+    }
+
+    server {
+        listen 127.0.0.1:8080;
+        server_name localhost;
+
+        auth_jwt_key_request /_jwks_uri;
+
+        set $oidc_authz_endpoint "http://127.0.0.1:%%IDP_PORT%%/auth";
+        set $oidc_authz_extra_args "";
+        set $oidc_token_endpoint "http://127.0.0.1:%%IDP_PORT%%/token";
+        set $oidc_jwt_keyfile "http://127.0.0.1:%%IDP_PORT%%/certs";
+        set $oidc_end_session_endpoint "";
+
+        set $oidc_client "%%CLIENT_ID%%";
+        set $oidc_client_secret "test-client-secret";
+        set $oidc_client_auth_method "client_secret_post";
+        set $oidc_scopes "openid";
+        set $oidc_hmac_key "test-hmac-key";
+        set $oidc_pkce_enable 0;
+
+        set $zone_sync_leeway 0;
+
+        include openid_connect.server_conf;
+
+        location = / {
+            auth_jwt "" token=$session_jwt;
+            error_page 401 = @do_oidc_flow;
+
+            add_header X-Test-AT "$access_token";
+            add_header X-Test-ID "$session_jwt";
+            add_header X-Test-ISS "$jwt_claim_iss";
+
+            proxy_pass http://127.0.0.1:8081;
+        }
+    }
+
+    server {
+        listen       127.0.0.1:8081;
+        server_name  localhost;
+
+        location / {
+            return 200 "FOO";
+        }
+    }
+}
+EOF
+
+$conf =~ s/%%TESTDIR%%/$d/g;
+$conf =~ s/%%IDP_PORT%%/$idp_port/g;
+$conf =~ s/%%CLIENT_ID%%/$client_id/g;
+
+$t->write_file_expand('nginx.conf', $conf);
+
+$Test::Nginx::OIDC::port = $idp_port;
+$t->run_daemon(\&idp_daemon, $issuer, $client_id, $jwt_secret)
+    ->waitforsocket('127.0.0.1:' . $idp_port);
+
+$t->run();
+
+my $api_version = (sort { $a <=> $b } @{ api('/api/') })[-1];
+
+###############################################################################
+
+my $flow = parse_response(http_get('/'));
+
+like($flow->{location}, qr/^\Q$issuer\E\/auth\?/, 'redirect to idp');
+
+is($flow->{response_type}, 'code', 'response_type');
+is($flow->{scope}, 'openid', 'default scope');
+
+ok(defined $flow->{state} && defined $flow->{nonce}, 'state and nonce are set');
+is($flow->{client_id}, $client_id, 'client_id');
+
+like($flow->{redirect_uri}, qr!^https?://localhost:8080/_codexch$!, 
+    'callback uri');
+
+my $set_cookie = join "\n", @{ $flow->{headers}{'set-cookie'} };
+like($set_cookie, qr/\bauth_redir=%2F;/, 'auth_redir is set');
+like($set_cookie, qr/\bauth_nonce=[0-9a-f]{32};/i, 'auth_nonce is set');
+
+set_state(nonce => $flow->{nonce});
+
+$flow = http(build_code_request($flow));
+$flow = parse_response($flow);
+
+like($flow->{cookie}, qr/^auth_token=[^;]+;/, 'session cookie auth_token');
+like($flow->{location}, qr!^http://localhost(?::\d+)?/(?:\?.*)?$!,
+    'redirect to original url'
+);
+
+my $cookie = $flow->{cookie};
+my $r = http_get_auth('/', $cookie);
+my $st = get_state();
+
+like($r, qr/FOO/, 'access granted');
+like($r, qr/X-Test-AT: \Q$st->{access_token}\E/s, 'access token variable');
+like($r, qr/X-Test-ID: \Q$st->{id_token}\E/s, 'id token variable');
+like($r, qr/X-Test-ISS: \Q$issuer\E/s, 'iss claim variable');
+is($st->{token_hits}, 1, '1 tokenset request');
+
+my ($session_id) = $flow->{cookie} =~ /^auth_token=([^;]+)/;
+is(get_kv('oidc_id_tokens')->{$session_id}, $st->{id_token}, 'kv id_token');
+is(get_kv('oidc_access_tokens')->{$session_id}, $st->{access_token},
+    'kv access_token');
+is(get_kv('refresh_tokens')->{$session_id}, $st->{refresh_token},
+    'kv refresh_token');
+is(get_kv('oidc_sids')->{sid1}, $session_id, 'kv sid to session id');
+is_deeply(get_kv('oidc_pkce'), {}, 'kv pkce is empty with pkce disabled');
+
+del_kv('/http/keyvals/oidc_id_tokens');
+like(http_get_auth('/', $cookie), qr/FOO/, 'session refreshed');
+
+# ###############################################################################
+
+sub http_get_auth {
+    my ($url, $cookie) = @_;
+    return http(<<EOF);
+GET $url HTTP/1.0
+Host: localhost
+Cookie: $cookie
+
+EOF
+}
+
+sub api {
+    http_get(shift) =~ /\x0d\x0a?\x0d\x0a?(.*)/ms;
+    return eval $1;
+}
+
+sub get_kv {
+    my ($zone) = @_;
+    my $r = http_get("/api/$api_version/http/keyvals/$zone");
+    $r =~ /\x0d\x0a?\x0d\x0a?(.*)/ms;
+    return JSON::PP::decode_json($1);
+}
+
+sub del_kv {
+    my ($url) = @_;
+    return http(<<EOF);
+DELETE /api/$api_version$url HTTP/1.1
+Host: localhost
+Connection: close
+
+EOF
+}
+
+###############################################################################


### PR DESCRIPTION
Basic Perl-based tests for OIDC have been added. So far, the following tests have been implemented:
ok 1 - redirect to idp
ok 2 - response_type
ok 3 - default scope
ok 4 - state and nonce are set
ok 5 - client_id
ok 6 - callback uri
ok 7 - auth_redir is set
ok 8 - auth_nonce is set
ok 9 - session cookie auth_token
ok 10 - redirect to original url
ok 11 - access granted
ok 12 - access token variable
ok 13 - id token variable
ok 14 - iss claim variable
ok 15 - 1 tokenset request
ok 16 - kv id_token
ok 17 - kv access_token
ok 18 - kv refresh_token
ok 19 - kv sid to session id
ok 20 - kv pkce is empty with pkce disabled
ok 21 - session refreshed
ok 22 - no alerts
ok 23 - no sanitizer errors