### PR TITLE
Prevent inherited body size checks in internal subrequests

### DIFF
--- a/openid_connect.server_conf
+++ b/openid_connect.server_conf
@@ -10,6 +10,7 @@
 
     location = /_jwks_uri {
         internal;
+        client_max_body_size 0;                       # Subrequest inherits parent Content-Length
         proxy_cache jwk;                              # Cache the JWK Set received from IdP
         proxy_cache_valid 200 12h;                    # How long to consider keys "fresh"
         proxy_cache_use_stale error timeout updating; # Use old JWK Set if cannot reach IdP
@@ -44,6 +45,7 @@
         # to construct the OpenID Connect token request, as per:
         #  http://openid.net/specs/openid-connect-core-1_0.html#TokenRequest
         internal;
+        client_max_body_size 0;      # Internal subrequest may inherit parent Content-Length
 
         # Exclude client headers to avoid CORS errors with certain IdPs (e.g., Microsoft Entra ID)
         proxy_pass_request_headers off;
@@ -63,6 +65,7 @@
         # use the proxy_ directives to construct the OpenID Connect token request, as per:
         #  https://openid.net/specs/openid-connect-core-1_0.html#RefreshingAccessToken
         internal;
+        client_max_body_size 0;      # Internal subrequest may inherit parent Content-Length
 
         # Exclude client headers to avoid CORS errors with certain IdPs (e.g., Microsoft Entra ID)
         proxy_pass_request_headers off;
@@ -81,6 +84,7 @@
         # Internal location to verify any JWT (e.g., id_token, logout_token)
         # using the auth_jwt module. Extracts the claims and returns them as JSON.
         internal;
+        client_max_body_size 0;      # Internal subrequest may inherit parent Content-Length
         auth_jwt "" token=$arg_token;
         js_content oidc.extractTokenClaims;
         error_page 500 502 504 @oidc_error;

--- a/t/oidc_session.t
+++ b/t/oidc_session.t
@@ -40,7 +40,7 @@ my $client_id  = 'test-client';
 my $jwt_secret = 'test-jwt-secret';
 my $issuer     = "http://127.0.0.1:$idp_port";
 
-my $t = Test::Nginx->new()->has(qw/http/)->plan(125);
+my $t = Test::Nginx->new()->has(qw/http/)->plan(126);
 my $d = $t->testdir();
 
 ###################################################################################################
@@ -144,6 +144,7 @@ http {
     server {
         listen 127.0.0.1:8080;
         server_name localhost;
+        client_max_body_size 4k;
 
         auth_jwt_key_request /_jwks_uri;
 
@@ -156,6 +157,14 @@ http {
             add_header X-Test-AT "$access_token";
             add_header X-Test-ID "$session_jwt";
             add_header X-Test-ISS "$jwt_claim_iss";
+
+            proxy_pass http://127.0.0.1:8081;
+        }
+
+        location = /upload {
+            client_max_body_size 64k;
+            auth_jwt "" token=$session_jwt;
+            error_page 401 = @do_oidc_flow;
 
             proxy_pass http://127.0.0.1:8081;
         }
@@ -640,6 +649,14 @@ for my $key (qw/refId message clientIp host method uri httpVersion/) {
 like($json_error->{message} // '', qr/OIDC expected authorization code but received: \/_codexch/,
     'oidc_error json has expected message');
 
+### large_post_body_during_jwks_fetch
+
+($cookie, $sid) = fresh_session('/');
+my $large_body = 'A' x 8192;
+$r = post('/upload', $large_body, $cookie);
+
+like($r, qr/FOO/, 'large POST body during JWKS fetch reaches backend');
+
 ###################################################################################################
 
 sub get {
@@ -652,6 +669,20 @@ sub get {
     push @headers, "Cookie: $cookie" if defined $cookie;
 
     return http(join("\n", @headers) . "\n\n");
+}
+
+sub post {
+    my ($url, $body, $cookie) = @_;
+    my $len = length($body);
+    my @headers = (
+        "POST $url HTTP/1.0",
+        "Host: localhost",
+        "Content-Length: $len",
+    );
+
+    push @headers, "Cookie: $cookie" if defined $cookie;
+
+    return http(join("\n", @headers) . "\n\n" . $body);
 }
 
 sub run_oidc_flow {


### PR DESCRIPTION
Large authenticated POST requests could fail with HTTP 500 error even when the target location allowed the request body size. The issue was caused by internal subrequests inheriting the parent request body length and being checked against `client_max_body_size` in non-interactive internal locations.

This change disables body size enforcement for those internal subrequest locations by setting `client_max_body_size 0;`.

Fixes #100 