### PR TITLE
Replace math.random with a crypographically secure rng

### DIFF
--- a/openid_connect.js
+++ b/openid_connect.js
@@ -448,6 +448,11 @@ function initiateNewAuth(r) {
     r.return(302, r.variables.oidc_authz_endpoint + getAuthZArgs(r));
 }
 
+function randomB64url(size) {
+    return Buffer.from(crypto.getRandomValues(new Uint8Array(size)))
+        .toString('base64url');
+}
+
 // Generate the authorization request arguments
 function getAuthZArgs(r) {
     var c = require('crypto');
@@ -471,10 +476,8 @@ function getAuthZArgs(r) {
     ];
 
     if (r.variables.oidc_pkce_enable == 1) {
-        var pkce_code_verifier = c.createHmac('sha256', r.variables.oidc_hmac_key)
-            .update(String(Math.random())).digest('hex');
-        r.variables.pkce_id = c.createHash('sha256')
-            .update(String(Math.random())).digest('base64url');
+        var pkce_code_verifier = randomB64url(32);
+        r.variables.pkce_id = randomB64url(32);
         var pkce_code_challenge = c.createHash('sha256')
             .update(pkce_code_verifier).digest('base64url');
         r.variables.pkce_code_verifier = pkce_code_verifier;

--- a/t/oidc_session.t
+++ b/t/oidc_session.t
@@ -349,7 +349,7 @@ $flow = run_oidc_flow('/');
 like($flow->{cookie}, qr/^auth_token=[^;]+;/, 'pkce auth success');
 
 $s = get_state();
-like($s->{code_verifier}, qr/^[0-9a-f]{64}$/i, 'pkce code_verifier sent to token request');
+like($s->{code_verifier}, qr/^[A-Za-z0-9_-]{43}$/, 'pkce code_verifier sent to token request');
 is($s->{auth_method}, '', 'pkce token request no client auth');
 
 set_conf({ oidc_pkce_enable => "0" });


### PR DESCRIPTION
Use CSPRNG base64url for PKCE secrets

Replace the HMAC/hash-wrapped Math.random() PKCE values with
crypto.getRandomValues via a small randomB64url() helper. Hashing
does not add entropy to a CSPRNG, and the 32 bytes from
getRandomValues are a ready-to-use secret, so createHmac/createHash
are dropped for the verifier and state (pkce_id). The code_challenge
remains BASE64URL(SHA256(code_verifier)) as required by PKCE S256.

Adjusts the test assertion for code_verifier from 64-hex to
43-char base64url to match the new format.