### PR TITLE
Fix empty Location header on OIDC error redirects

### DIFF
--- a/openid_connect.js
+++ b/openid_connect.js
@@ -39,8 +39,7 @@ async function auth(r, afterSyncCheck) {
     } catch (e) {
         // If validation failed, reset and reinitiate auth
         r.variables.refresh_token = "-";
-        r.headersOut["Location"] = r.variables.request_uri;
-        oidcError(r, 302, getRefId(r, "auth.validate"), e);
+        oidcError(r, 302, getRefId(r, "auth.validate"), e, r.variables.request_uri);
         return;
     }
 
@@ -302,8 +301,7 @@ async function refreshTokens(r) {
         return tokenset;
     } catch (_e) {
         r.variables.refresh_token = "-";
-        r.headersOut["Location"] = r.variables.request_uri;
-        oidcError(r, 302, getRefId(r, "refresh.parse"), new Error("OIDC refresh response not JSON"));
+        oidcError(r, 302, getRefId(r, "refresh.parse"), new Error("OIDC refresh response not JSON"), r.variables.request_uri);
         return null;
     }
 }
@@ -547,8 +545,7 @@ function handleRefreshError(r, reply) {
     }
 
     r.variables.refresh_token = "-";
-    r.headersOut["Location"] = r.variables.request_uri;
-    oidcError(r, 302, ref, new Error(errorLog));
+    oidcError(r, 302, ref, new Error(errorLog), r.variables.request_uri);
 }
 
 /* If the ID token has not been synced yet, poll the variable every 100ms until
@@ -568,7 +565,7 @@ function retryOriginalRequest(r) {
     r.internalRedirect(r.variables.uri + r.variables.is_args + (r.variables.args || ''));
 }
 
-function oidcError(r, http_code, refId, e) {
+function oidcError(r, http_code, refId, e, location) {
     const hasDebug = !!r.variables.oidc_debug;
     const msg = (e && e.message) ? String(e.message) : (e ? String(e) : "Unexpected Error");
     const stack = (hasDebug && e && e.stack) ? String(e.stack) : "";
@@ -606,7 +603,11 @@ function oidcError(r, http_code, refId, e) {
             : `ReferenceID: ${refId} ${msg}`;
     }
 
-    r.return(http_code);
+    if (location !== undefined) {
+        r.return(http_code, location);
+    } else {
+        r.return(http_code);
+    }
 }
 
 function getRefId(r, context) {

--- a/t/oidc_session.t
+++ b/t/oidc_session.t
@@ -40,7 +40,7 @@ my $client_id  = 'test-client';
 my $jwt_secret = 'test-jwt-secret';
 my $issuer     = "http://127.0.0.1:$idp_port";
 
-my $t = Test::Nginx->new()->has(qw/http/)->plan(126);
+my $t = Test::Nginx->new()->has(qw/http/)->plan(127);
 my $d = $t->testdir();
 
 ###################################################################################################
@@ -284,7 +284,7 @@ isnt($access_after, $access_before, 'access token rotated');
 my $refresh_after = get_kv('refresh_tokens')->{$sid};
 isnt($refresh_after, $refresh_before, 'refresh token rotated');
 
-### refresh_error_400_json (TODO: check redir to orig uri)
+### refresh_error_400_json
 
 ($cookie, $sid) = fresh_session('/');
 patch_kv('oidc_id_tokens', { $sid => undef });
@@ -292,11 +292,12 @@ patch_kv('refresh_tokens', { $sid => 'foo' });
 $flow = parse_response(get('/?foo=bar', $cookie));
 
 is($flow->{status}, 302, 'refresh 400 json error returns 302');
-like($flow->{raw}, qr/\r?\nLocation:\s*\r?\n/s, 'refresh 400 json redirect');
+like($flow->{raw}, qr{\r?\nLocation:[^\r\n]*/\?foo=bar\r?\n}s,
+    'refresh 400 json redirect to orig uri');
 like(get_logs(), qr/refresh\s+failure.*invalid_grant.*invalid refresh_token/s,
     'refresh 400 json error log');
 
-### refresh_error_none_400 (TODO: check redir to orig uri)
+### refresh_error_none_400
 
 ($cookie, $sid) = fresh_session('/');
 patch_kv('oidc_id_tokens', { $sid => undef });
@@ -305,6 +306,8 @@ $flow = parse_response(get('/?foo=baz', $cookie));
 set_state(token_status => '');
 
 is($flow->{status}, 302, 'refresh 500 error returns 302');
+like($flow->{raw}, qr{\r?\nLocation:[^\r\n]*/\?foo=baz\r?\n}s,
+    'refresh 500 redirect to orig uri');
 like(get_logs(), qr/refresh\s+failure.*500/s, 'refresh status 500 error log');
 
 ### refresh_200_json_without_id_token
@@ -327,7 +330,8 @@ $flow = parse_response(get('/?foo=aud', $cookie));
 set_state(client_id => $client_id);
 
 is($flow->{status}, 302, 'refresh with invalid id_token claims returns 302');
-like($flow->{raw}, qr/\r?\nLocation:\s*\r?\n/s, 'refresh validate failure redirect');
+like($flow->{raw}, qr{\r?\nLocation:[^\r\n]*/\?foo=aud\r?\n}s,
+    'refresh validate failure redirect to orig uri');
 like(get_logs(), qr/aud\s+claim.*does\s+not\s+include/s, 'refresh validate error log');
 is(get_kv('refresh_tokens')->{$sid}, '-', 'refresh token kv reset');
 


### PR DESCRIPTION
For 302 redirect nginx calls ngx_http_clear_location() and rebuilds the Location header from r.return() body argument, so the manually set header was wiped and replaced with an empty value. Need to pass the redirect URI as r.return()'s second argument.